### PR TITLE
Adding missing devDependency (Grunt)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "authors": [
     "benjaminapetersen <admin@benjaminapetersen.me>",
-		"sg00dwin <sgoodwin@redhat.com"
+    "sg00dwin <sgoodwin@redhat.com>"
   ],
   "bugs": {
     "url": "https://github.com/benjaminapetersen/layout.attrs/issues"
@@ -23,6 +23,7 @@
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
     "cssnano": "^2.0.0",
+    "grunt": "^0.4.0",
     "grunt-autoprefixer": "^3.0.3",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-cssmin": "^0.12.2",


### PR DESCRIPTION
Without Grunt specified in the devDependencies, running `grunt` after `npm install` no worky.
